### PR TITLE
Remove imports with side-effects

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,17 +15,18 @@ module.exports = function (opts) {
           const node = path.node;
           const fileName = node.source.value;
 
-          if (node.specifiers.length < 1) {
-            // Import is not being given a name, no need to replace it.
-            return;
-          }
-
           // Bail unless the filename we're importing matches one of the
           // extensions we're filtering on.
           const matchedExtensions = (state.opts && state.opts.extensions) || defaultExtensions;
           const matchPattern = new RegExp('(' + matchedExtensions.join('|') + ')$');
 
           if (!matchPattern.test(fileName)) {
+            return;
+          }
+
+          if (node.specifiers.length < 1) {
+            // Import is not being given a name, remove it (it's most likely for webpack's sake).
+            path.remove();
             return;
           }
 


### PR DESCRIPTION
In our code-base we use javascript imports to signal webpack to load CSS as part of the build process and it looks something like `import 'foo.css';`; instead of ignoring it, this removes the line from the transpiled code.
